### PR TITLE
Correction of the array of route groups before and after. array_value…

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -388,8 +388,8 @@ class Router
             $group['after'] = $list['after'];
         }
 
-        $group['before'] = array_values(array_unique($group['before']));
-        $group['after'] = array_values(array_unique($group['after']));
+        $group['before'] = array_values(array_unique( (array) $group['before']));
+        $group['after'] = array_values(array_unique( (array) $group['after']));
 
         array_push($this->groups, $group);
 


### PR DESCRIPTION
Correction of the array of route groups before and after. array_values () expects the parameter to be an array. I forced a type conversion to avoid warnings. Lines 391 and 392