### PR TITLE
Initialize route request tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,22 @@
 language: php
-php:
-  - "7.1"
-  - "7.0"
-  - "5.6"
-  - "5.5"
-  - "5.4"
+
+matrix:
+  include:
+  - php: 5.4
+  - php: 5.5
+  - php: 5.6
+  - php: 7.0
+  - php: 7.1
+  - php: 7.2
+  - php: 7.3
+
+sudo: false
+
+install:
+  - composer install
+
+before_script:
+  - php -S localhost:5000 tests/fixtures/server.php &
+
+script:
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,18 @@
   "require": {
     "php": ">=5.4.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.0",
+    "guzzlehttp/guzzle": "^5.3"
+  },
   "autoload": {
     "psr-4": {
   		"Buki\\": "src"
   	}
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Buki\\Tests\\": "tests/"
+    }
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/bootstrap.php">
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+
     <testsuites>
         <testsuite name="Router Tests">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+
     <filter>
         <whitelist>
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
+
 </phpunit>

--- a/src/Router.php
+++ b/src/Router.php
@@ -75,7 +75,7 @@ class Router
 
     /**
      * Router constructor method.
-     * 
+     *
      * @param array $params
      *
      * @return void
@@ -105,24 +105,24 @@ class Router
     protected function setPaths($params)
     {
         if (isset($params['paths']) && $paths = $params['paths']) {
-            $this->paths['controllers']	= 
+            $this->paths['controllers']	=
                 isset($paths['controllers'])
                     ? trim($paths['controllers'], '/')
                     : $this->paths['controllers'];
 
-            $this->paths['middlewares']	= 
+            $this->paths['middlewares']	=
                 isset($paths['middlewares'])
                     ? trim($paths['middlewares'], '/')
                     : $this->paths['middlewares'];
         }
 
         if (isset($params['namespaces']) && $namespaces = $params['namespaces']) {
-            $this->namespaces['controllers'] = 
+            $this->namespaces['controllers'] =
                 isset($namespaces['controllers'])
                     ? trim($namespaces['controllers'], '\\') . '\\'
                     : '';
 
-            $this->namespaces['middlewares'] = 
+            $this->namespaces['middlewares'] =
                 isset($namespaces['middlewares'])
                     ? trim($namespaces['middlewares'], '\\') . '\\'
                     : '';
@@ -197,10 +197,10 @@ class Router
      * Add new route method one or more http methods.
      *
      * @param string $methods
-     * @param string $route 
+     * @param string $route
      * @param array|string|closure $settings
      * @param string|closure $callback
-     * 
+     *
      * @return void
      */
     public function add($methods, $route, $settings, $callback = null)
@@ -228,7 +228,7 @@ class Router
      *
      * @param string|array $pattern
      * @param null|string $attr
-     * 
+     *
      * @return void
      * @throws
      */
@@ -350,10 +350,10 @@ class Router
     /**
      * Routes Group
      *
-     * @param string $name 
+     * @param string $name
      * @param closure|array $settings
      * @param null|closure $callback
-     * 
+     *
      * @return void
      */
     public function group($name, $settings = null, $callback = null)
@@ -376,12 +376,12 @@ class Router
             foreach ($this->groups as $key => $value) {
                 if (is_array($value['before'])) {
                     foreach ($value['before'] as $k => $v) {
-                        $list['before'][] = $v;    
+                        $list['before'][] = $v;
                     }
                     foreach ($value['after'] as $k => $v) {
-                        $list['after'][] = $v;    
+                        $list['after'][] = $v;
                     }
-                } 
+                }
             }
 
             if (! is_null($group['before'])) {
@@ -414,7 +414,7 @@ class Router
      * @param string $route
      * @param string|array $settings
      * @param null|string $controller
-     * 
+     *
      * @return void
      * @throws
      */
@@ -429,7 +429,7 @@ class Router
         $controllerFile = realpath(
             rtrim($this->paths['controllers'], '/') . '/' . $controller . '.php'
         );
-        
+
         if (! file_exists($controllerFile)) {
             return $this->exception($controller . ' class is not found!');
         }
@@ -474,7 +474,7 @@ class Router
      * Routes error function. (Closure)
      *
      * @param $callback
-     * 
+     *
      * @return void
      */
     public function error($callback)
@@ -486,10 +486,10 @@ class Router
      * Add new Route and it's settings
      *
      * @param $uri
-     * @param $method 
+     * @param $method
      * @param $callback
      * @param $settings
-     * 
+     *
      * @return void
      */
     private function addRoute($uri, $method, $callback, $settings)
@@ -523,11 +523,11 @@ class Router
                 ? $settings['name']
                 : null
             ),
-            'before' => (isset($settings['before']) 
+            'before' => (isset($settings['before'])
                 ? $settings['before']
                 : null
             ),
-            'after' => (isset($settings['after']) 
+            'after' => (isset($settings['after'])
                 ? $settings['after']
                 : null
             ),
@@ -556,9 +556,9 @@ class Router
     /**
      * Detect Routes Middleware; before or after
      *
-     * @param $middleware 
+     * @param $middleware
      * @param $type
-     * 
+     *
      * @return void
      */
     public function runRouteMiddleware($middleware, $type)
@@ -621,7 +621,7 @@ class Router
 
     /**
      * Throw new Exception for Router Error
-     * 
+     *
      * @param $message
      *
      * @return RouterException

--- a/src/Router/RouterCommand.php
+++ b/src/Router/RouterCommand.php
@@ -47,9 +47,9 @@ class RouterCommand
      * Run Route Middlewares
      *
      * @param $command
-     * @param $path 
+     * @param $path
      * @param $namespace
-     * 
+     *
      * @return mixed|void
      * @throws
      */
@@ -69,18 +69,18 @@ class RouterCommand
                 return $this->exception('handle() method is not found in <b>'.$command.'</b> class.');
             }
         }
-        
+
         return;
     }
 
     /**
      * Run Route Command; Controller or Closure
      *
-     * @param $command 
-     * @param $params 
-     * @param $path 
-     * @param $namespace 
-     * 
+     * @param $command
+     * @param $params
+     * @param $path
+     * @param $namespace
+     *
      * @return void
      * @throws
      */
@@ -99,13 +99,13 @@ class RouterCommand
                 );
                 return;
             }
- 
+
             return $this->exception($controllerMethod . ' method is not found in '.$controllerClass.' class.');
         } else {
             if (! is_null($params)) {
                 echo call_user_func_array($command, $params);
                 return;
-            } 
+            }
 
             echo call_user_func($command);
         }
@@ -114,10 +114,10 @@ class RouterCommand
     /**
      * Resolve Controller or Middleware class.
      *
-     * @param $class 
-     * @param $path 
-     * @param $namespace  
-     * 
+     * @param $class
+     * @param $path
+     * @param $namespace
+     *
      * @return object
      * @throws
      */
@@ -130,7 +130,7 @@ class RouterCommand
 
         require_once($file);
         $class = $namespace . str_replace('/', '\\', $class);
-        
+
         return new $class();
     }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -1,9 +1,23 @@
 <?php
 
-class RouterTest extends PHPUnit_Framework_TestCase
+namespace Buki\Tests;
+
+use Buki\Router;
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class RouterTest extends TestCase
 {
+    protected $router;
+
+    protected $client;
+
     protected function setUp()
     {
+        $this->router = new Router();
+
+        $this->client = new Client();
+
         // Clear SCRIPT_NAME because bramus/router tries to guess the subfolder the script is run in
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
@@ -19,8 +33,25 @@ class RouterTest extends PHPUnit_Framework_TestCase
         // nothing
     }
 
+    public function testGetIndexRoute()
+    {
+        $request = $this->client->createRequest('GET', 'http://localhost:5000/');
+        $response = $this->client->send($request);
+
+        $this->assertSame('Hello World!', (string) $response->getBody());
+    }
+
+    /**
+     * @expectedException GuzzleHttp\Exception\ClientException
+     */
+    public function testGetNotFoundRoute()
+    {
+        $request = $this->client->createRequest('GET', 'http://localhost:5000/not/found');
+        $response = $this->client->send($request);
+    }
+
     public function testInit()
     {
-        $this->assertInstanceOf('\Buki\Router', new \Buki\Router());
+        $this->assertInstanceOf('\Buki\Router', new Router());
     }
 }

--- a/tests/fixtures/TestController.php
+++ b/tests/fixtures/TestController.php
@@ -1,0 +1,9 @@
+<?php
+
+class TestController
+{
+    public function main(Request $request)
+    {
+        return 'Hello World!';
+    }
+}

--- a/tests/fixtures/server.php
+++ b/tests/fixtures/server.php
@@ -1,0 +1,11 @@
+<?php
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$router = new Buki\Router();
+
+$router->get('/', function() {
+    return 'Hello World!';
+});
+
+$router->run();


### PR DESCRIPTION
# Changed log
- Remove disallowed attribute and set current attribute settings in `phpunit.xml.dist` setting file.
- Add `require-dev` and `autoload-dev` to define development requirement and namespace in the development environment.
- To do the route request test, add the `guzzlehttp/guzzle` package to complete this requirement.
- Using the `Guzzle` `5.3.x` version to be compatible with `php-5.4` version.
- Initialize the basic route request test in Travis CI build.
- The latest Travis CI build log is available [here](https://travis-ci.org/izniburak/php-router/builds/475797084).
