### PR TITLE
Using PHP 5.5 version test at least

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: php
 
+dist: trusty
+
 matrix:
   include:
-  - php: 5.4
   - php: 5.5
   - php: 5.6
   - php: 7.0
   - php: 7.1
   - php: 7.2
   - php: 7.3
+  - php: 7.4
 
 sudo: false
 


### PR DESCRIPTION
# Changed log
- Remove `php-5.4` and add `php-7.4` version tests during Travis CI build.
- According to the [composer.json](https://github.com/izniburak/php-router/blob/master/composer.json#L16), the package requires `php-5.5` version at least.