### PR TITLE
Group specific error pages and prefix error pages

### DIFF
--- a/tests/error-test.php
+++ b/tests/error-test.php
@@ -1,0 +1,42 @@
+<?php
+
+$router->group('/test', function ($router) {
+    $router->get('/',function () use ($router) {
+        return 'text page';
+    });
+    $router->get('/blue',function () {
+       echo 'blue page';
+    });
+    $router->group('/testing', function ($rou) {
+        $rou->get('/',function () {
+            echo 'testing page';
+        });
+        $rou->error(function () {
+            echo 'testing error page';
+        });
+    });
+
+
+    $router->error(function () {
+        echo 'test error page';
+    });
+});
+
+$router->group('/test2', function ($router) {
+    $router->get('/',function () {
+        echo 'test2 page';
+    });
+    $router->get('/yellow',function () {
+        echo 'yellow page';
+    });
+    $router->error(function () {
+        die('test2 error page');
+    });
+});
+
+
+$router->error(function () {
+    echo 'main error page';
+});
+
+$router->error('home@notfound',['prefix' => '/test3']);


### PR DESCRIPTION
I tried my best to do. I would be very happy if I could contribute.
I did the question I asked today and a little more.

I added the following features;

Error pages created in groups are now specific to that group
```
$router->group('/test', function ($router) {
    $router->get('/',function () use ($router) {
        return 'text page';
    });
    $router->get('/blue',function () {
       echo 'blue page';
    });
    $router->group('/testing', function ($rou) {
        $rou->get('/',function () {
            echo 'testing page';
        });
        $rou->error(function () {
            echo 'testing error page';
        });
    });


    $router->error(function () {
        echo 'test error page';
    });
});
```

'home@notfound' is now available in error function
```
$router->error('home@notfound');
```

route prefix can be set in error function regardless of group
```
$router->error('home@notfound',['prefix' => '/test']);
```

That's all,
maybe it could have been better. That's as much as I can. I really need this feature